### PR TITLE
Carousel navigation controls

### DIFF
--- a/src/bookmarklet/_includes/css/blocks.css
+++ b/src/bookmarklet/_includes/css/blocks.css
@@ -72,6 +72,26 @@
    background-color: var(--color-black);
 }
 
+.spellcheck-carousel__nav .sb-bob-arrow {
+   display: none;
+}
+
+@media not all and (pointer: coarse) {
+   .spellcheck-carousel__nav {
+      align-items: center;
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      padding-left: var(--space-outer);
+      padding-right: var(--space-outer);
+   }
+
+   .spellcheck-carousel__nav .sb-bob-arrow {
+      display: block;
+      left: 0;
+      position: relative;
+      right: 0;
+   }
+}
 
 
 

--- a/src/bookmarklet/_includes/partials/modals/main.njk
+++ b/src/bookmarklet/_includes/partials/modals/main.njk
@@ -4,5 +4,15 @@
 		{{- partial('components/tll/tll.njk') -}}
 	</div>
 
-	<div class="spellcheck-carousel__dots"></div>
+	<div class="spellcheck-carousel__nav">
+		<button type="button" class="sb-bob-arrow sb-bob-prev">
+			<span class="sb-bob-text">Previous</span>
+		</button>
+
+		<div class="spellcheck-carousel__dots"></div>
+
+		<button type="button" class="sb-bob-arrow sb-bob-next active">
+			<span class="sb-bob-text">Next</span>
+		</button>
+	</div>
 </div>

--- a/src/bookmarklet/app.mjs.njk
+++ b/src/bookmarklet/app.mjs.njk
@@ -223,11 +223,71 @@ export default class App
 		});
 
 		/*
-		 * Carousel dots
+		 * Carousel
 		 */
 		const carouselCards = document.querySelector( ".spellcheck-carousel__cards" );
 		if( carouselCards && carouselCards.childElementCount > 1 )
 		{
+			const carouselState = {
+				currentCard: 0,
+			};
+
+			const prevArrow = document.querySelector( '.spellcheck-carousel__nav .sb-bob-prev' );
+			const nextArrow = document.querySelector( '.spellcheck-carousel__nav .sb-bob-next' );
+
+			const handleKeydown = (event) =>
+			{
+				if( event.key === 'ArrowLeft' )
+				{
+					showPrevCard();
+				}
+				if( event.key === 'ArrowRight' )
+				{
+					showNextCard();
+				}
+			};
+
+			const scrollBehavior = () =>
+			{
+				const motionMediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+				return (!motionMediaQuery || motionMediaQuery.matches) ? "auto" : "smooth";
+			}
+
+			const showPrevCard = () =>
+			{
+				if( carouselState.currentCard > 0 )
+				{
+					const prevCard = carouselCards.childNodes[carouselState.currentCard - 1];
+					prevCard.scrollIntoView( {
+						behavior: scrollBehavior(),
+						block: "nearest",
+						inline: "nearest",
+					} );
+				}
+			}
+
+			const showNextCard = () =>
+			{
+				if( carouselState.currentCard < carouselCards.childElementCount - 1 )
+				{
+					const nextCard = carouselCards.childNodes[carouselState.currentCard + 1];
+					nextCard.scrollIntoView( {
+						behavior: scrollBehavior(),
+						block: "nearest",
+						inline: "nearest",
+					} );
+				}
+			}
+
+			prevArrow.addEventListener( "click", showPrevCard );
+			nextArrow.addEventListener( "click", showNextCard );
+			document.addEventListener( "keydown", handleKeydown );
+
+			UI.onHideModal( () =>
+			{
+				document.removeEventListener( "keydown", handleKeydown );
+			});
+
 			carouselCards.addEventListener( "scroll", (event) =>
 			{
 				const cardIndex = Math.round(
@@ -235,6 +295,8 @@ export default class App
 					event.target.scrollWidth *
 					carouselCards.childElementCount
 				);
+
+				carouselState.currentCard = cardIndex;
 
 				document.querySelectorAll( ".spellcheck-carousel__dot" ).forEach( (dotElement, dotIndex) =>
 				{
@@ -247,6 +309,30 @@ export default class App
 						dotElement.dataset.active = "false";
 					}
 				});
+
+				/*
+				 * Arrows
+				 */
+				const showPrev = cardIndex > 0;
+				const showNext = cardIndex < carouselCards.childElementCount - 1;
+
+				if( showPrev )
+				{
+					prevArrow.classList.add( 'active' );
+				}
+				else
+				{
+					prevArrow.classList.remove( 'active' );
+				}
+
+				if( showNext )
+				{
+					nextArrow.classList.add( 'active' );
+				}
+				else
+				{
+					nextArrow.classList.remove( 'active' );
+				}
 			});
 			carouselCards.style.setProperty( "--carousel-columns", carouselCards.childElementCount );
 

--- a/src/bookmarklet/app.mjs.njk
+++ b/src/bookmarklet/app.mjs.njk
@@ -283,7 +283,7 @@ export default class App
 			nextArrow.addEventListener( "click", showNextCard );
 			document.addEventListener( "keydown", handleKeydown );
 
-			UI.onHideModal( () =>
+			UI.addEventListener( "modalhide", () =>
 			{
 				document.removeEventListener( "keydown", handleKeydown );
 			});

--- a/src/bookmarklet/ui.mjs.njk
+++ b/src/bookmarklet/ui.mjs.njk
@@ -1,7 +1,7 @@
 /* {% from "system/loader.njk" import partial %} */
 
 const handlers = {
-	onHide: [],
+	modalhide: [],
 }
 
 let handleKeydown = (event) =>
@@ -19,11 +19,22 @@ let hideModal = () =>
 
 	document.removeEventListener( "keydown", handleKeydown );
 
-	handlers.onHide.forEach( (callback) => callback() );
-	handlers.onHide = [];
+	handlers.modalhide.forEach( (callback) => callback() );
+	handlers.modalhide = [];
 };
 
 const UI = {
+	/**
+	 * @param {string} eventName
+	 * @param {Function} callback
+	 */
+	addEventListener: (eventName, callback) => {
+		if( handlers[eventName] )
+		{
+			handlers[eventName].push( callback );
+		}
+	},
+
 	addStyles: () =>
 	{
 		/* eslint-disable quotes */
@@ -69,10 +80,6 @@ const UI = {
 
 	hideModal: () => {
 		hideModal();
-	},
-
-	onHideModal: (callback) => {
-		handlers.onHide.push( callback );
 	},
 
 	/* {# */

--- a/src/bookmarklet/ui.mjs.njk
+++ b/src/bookmarklet/ui.mjs.njk
@@ -1,5 +1,9 @@
 /* {% from "system/loader.njk" import partial %} */
 
+const handlers = {
+	onHide: [],
+}
+
 let handleKeydown = (event) =>
 {
 	if( event.key === "Escape" )
@@ -14,6 +18,9 @@ let hideModal = () =>
 	document.querySelector( ".sb-modal-wrapper" ).innerHTML = "";
 
 	document.removeEventListener( "keydown", handleKeydown );
+
+	handlers.onHide.forEach( (callback) => callback() );
+	handlers.onHide = [];
 };
 
 const UI = {
@@ -62,6 +69,10 @@ const UI = {
 
 	hideModal: () => {
 		hideModal();
+	},
+
+	onHideModal: (callback) => {
+		handlers.onHide.push( callback );
 	},
 
 	/* {# */


### PR DESCRIPTION
## Summary

Adds left and right navigation arrows to page carousel cards without relying on touch interactions, shown on devices without touch input:

![next](https://user-images.githubusercontent.com/3238096/173984075-957d5db8-2089-4530-96b5-1602df7d602e.png)

![prev](https://user-images.githubusercontent.com/3238096/173984079-438267d1-e36e-4109-b597-05f39a063db1.png)

Also adds support for navigating with keyboard arrow keys.

## Related Issues

Fixes #2 